### PR TITLE
Added teleport option to the buffer

### DIFF
--- a/buffer.lua
+++ b/buffer.lua
@@ -7,7 +7,7 @@
 
 	MIT
 	See license.txt for more information
-	
+
 ]]--
 
 -- for lazy programmers
@@ -42,13 +42,21 @@ local function remote_station_name(pos)
 	return "none"
 end
 
-local function on_punch(pos, node, puncher)	
-	local name = M(pos):get_string("name")
-	M(pos):set_string("infotext", name..": "..S("connected to").." "..remote_station_name(pos))
-	M(pos):set_string("formspec", formspec(pos))
-	if minecart.hopper_enabled then
-		minetest.get_node_timer(pos):start(CYCLE_TIME)
-	end
+local function on_punch(pos, node, puncher)
+	 local name = M(pos):get_string("name")
+	 M(pos):set_string("infotext", name..": "..S("connected to").." "..remote_station_name(pos))
+	 M(pos):set_string("formspec", formspec(pos))
+	 if minecart.hopper_enabled then
+			 minetest.get_node_timer(pos):start(CYCLE_TIME)
+	 end
+	 -- Optional Teleport function
+	 if not minecart.teleport_enabled then return end
+	 local route = minecart.get_route(P2S(pos))
+	 if route and route.dest_pos and puncher and puncher:is_player() then
+			 if not puncher:get_player_control()['sneak'] then
+					 puncher:set_pos(S2P(route.dest_pos))
+			 end
+	 end
 end
 
 minetest.register_node("minecart:buffer", {
@@ -118,7 +126,7 @@ minetest.register_node("minecart:buffer", {
 			M(pos):set_string("name", fields.name)
 			M(pos):set_int("time", tonumber(fields.time) or 0)
 			M(pos):set_string("formspec", formspec(pos))
-			M(pos):set_string("infotext", fields.name.." "..S("connected to").." "..remote_station_name(pos))			
+			M(pos):set_string("infotext", fields.name.." "..S("connected to").." "..remote_station_name(pos))
 		end
 	end,
 	on_punch = on_punch,

--- a/buffer.lua
+++ b/buffer.lua
@@ -43,20 +43,20 @@ local function remote_station_name(pos)
 end
 
 local function on_punch(pos, node, puncher)
-	 local name = M(pos):get_string("name")
-	 M(pos):set_string("infotext", name..": "..S("connected to").." "..remote_station_name(pos))
-	 M(pos):set_string("formspec", formspec(pos))
-	 if minecart.hopper_enabled then
-			 minetest.get_node_timer(pos):start(CYCLE_TIME)
-	 end
-	 -- Optional Teleport function
-	 if not minecart.teleport_enabled then return end
-	 local route = minecart.get_route(P2S(pos))
-	 if route and route.dest_pos and puncher and puncher:is_player() then
-			 if not puncher:get_player_control()['sneak'] then
-					 puncher:set_pos(S2P(route.dest_pos))
-			 end
-	 end
+	local name = M(pos):get_string("name")
+	M(pos):set_string("infotext", name..": "..S("connected to").." "..remote_station_name(pos))
+	M(pos):set_string("formspec", formspec(pos))
+	if minecart.hopper_enabled then
+		minetest.get_node_timer(pos):start(CYCLE_TIME)
+	end
+	-- Optional Teleport function
+	if not minecart.teleport_enabled then return end
+	local route = minecart.get_route(P2S(pos))
+	if route and route.dest_pos and puncher and puncher:is_player() then
+		if not puncher:get_player_control()['sneak'] then
+			puncher:set_pos(S2P(route.dest_pos))
+		end
+	end
 end
 
 minetest.register_node("minecart:buffer", {

--- a/init.lua
+++ b/init.lua
@@ -7,7 +7,7 @@
 
 	MIT
 	See license.txt for more information
-	
+
 ]]--
 
 minecart = {}
@@ -16,6 +16,7 @@ minecart = {}
 minecart.version = 1.09
 
 minecart.hopper_enabled = minetest.settings:get_bool("minecart_hopper_enabled") ~= false
+minecart.teleport_enabled = minetest.settings:get_bool("minecart_teleport_enabled") ~= false
 
 print("minecart_hopper_enabled", dump(minetest.settings:get_bool("minecart_hopper_enabled")))
 

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,2 +1,3 @@
 # If enabled, allows the complete automation of Minecarts by means of Hopper and station stop times.
 minecart_hopper_enabled (Hopper enabled) bool true
+minecart_teleport_enabled (Teleport enabled) bool false


### PR DESCRIPTION
_Probably could do this in german, but for the sake of consistency..._

On our server we need a teleport system for practical reasons since distances are getting unpractically large (15 min+ cart ride one direction) and we want to have a different area for fresh players. 

However we still want the exploration and construction effort to making new regions accessible. Thus I modified your mod so that once two buffers have been connected they can be used as a teleporter. I figure other people might be interested in that feature. 

I made it configurable with default to disabled so adding it should not bother anyone. 


