### PR TITLE
Try to fix rare carts sound playing to all users

### DIFF
--- a/entitylib.lua
+++ b/entitylib.lua
@@ -190,7 +190,7 @@ local function play_sound(self)
 	if self.object then
 		self.sound_handle = minetest.sound_play(
 			"carts_cart_moving", {
-			pos = self.object:get_pos(),
+			object = self.object,
 			gain = (self.curr_speed or 0) / MAX_SPEED,
 		})
 	end


### PR DESCRIPTION
Sometimes, all users on the server report hearing a rail sound simultaneously, even when they're spread out across the map. I suspect this to be related to minecarts, since only MTG's carts mod and this mod utilise the `carts_cart_moving` sound that is played.

This PR syncs the sound spec to the one [used in mtg](https://github.com/minetest/minetest_game/blob/9bcf2d46d0a675e51447a24db84a4f8a0614936d/mods/carts/cart_entity.lua#L167-L171) as well. While I'm not certain that this will fix the issue, I don't see any downsides making this change either. 